### PR TITLE
Remove support for K&R function definitions

### DIFF
--- a/doc/uC_Grammar.ipynb
+++ b/doc/uC_Grammar.ipynb
@@ -26,7 +26,7 @@
     "<global_declaration> ::= <function_definition>\n",
     "                       | <declaration>\n",
     "\n",
-    "<function_definition> ::= <type_specifier> <declarator> {<declaration>}* <compound_statement>\n",
+    "<function_definition> ::= <type_specifier> <declarator> <compound_statement>\n",
     "\n",
     "<type_specifier> ::= void\n",
     "                   | char\n",


### PR DESCRIPTION
## What?

Simplify function definition production by removing K&R-style definitions.

## Why?

It is a very uncommon form of function definition which is mostly unused and makes it difficult to understand uC's grammar.

## How?

The full function definition production is as it follows:
```
<function_definition> ::= <type_specifier> <declarator> {<declaration>}*  <compound_statement>
```

The `{<declaration>}*` item is used only in K&R-style definitions:
```


A regular function definition:
```
int main (int a, int b) { return a + b;}

```